### PR TITLE
Return false if key not present in the cache, currently returning 0

### DIFF
--- a/src/main/java/com/starter/springboot/services/OtpGenerator.java
+++ b/src/main/java/com/starter/springboot/services/OtpGenerator.java
@@ -56,12 +56,7 @@ public class OtpGenerator {
      */
     public Integer getOPTByKey(String key)
     {
-        try {
-            return otpCache.get(key);
-        }
-        catch (ExecutionException e) {
-            return -1;
-        }
+        return otpCache.getIfPresent(key);
     }
 
     /**

--- a/src/main/java/com/starter/springboot/services/OtpService.java
+++ b/src/main/java/com/starter/springboot/services/OtpService.java
@@ -76,7 +76,7 @@ public class OtpService {
     {
         // get OTP from cache
         Integer cacheOTP = otpGenerator.getOPTByKey(key);
-        if (cacheOTP.equals(otpNumber))
+        if (cacheOTP!=null && cacheOTP.equals(otpNumber))
         {
             otpGenerator.clearOTPFromCache(key);
             return true;


### PR DESCRIPTION
- get() on cache will return 0 if key is not present
- if otp of 0 is submitted while validation, it will return true which should not be expected behaviour